### PR TITLE
added coredata mechanism for items, need to test

### DIFF
--- a/StudyBuddyApp/StudyBuddyApp/Models/Item.swift
+++ b/StudyBuddyApp/StudyBuddyApp/Models/Item.swift
@@ -1,11 +1,13 @@
 import Foundation
 
-enum AccessoryItemCategory{
-  case Hat
+enum AccessoryItemCategory:String{
+  case Hat = "Hat"
 }
 
-enum PlaygroundItemCategory{
-  case Wall, Ceiling, Floor
+enum PlaygroundItemCategory:String{
+  case Wall = "Wall"
+  case Ceiling = "Ceiling"
+  case Floor = "Floor"
 }
 
 protocol Item : Hashable{

--- a/StudyBuddyApp/StudyBuddyApp/StudyBuddyApp.xcdatamodeld/StudyBuddyApp.xcdatamodel/contents
+++ b/StudyBuddyApp/StudyBuddyApp/StudyBuddyApp.xcdatamodeld/StudyBuddyApp.xcdatamodel/contents
@@ -1,9 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17709" systemVersion="20F71" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="ItemEntity" representedClassName="ItemEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="category" optional="YES" attributeType="String"/>
+        <attribute name="image" optional="YES" attributeType="String"/>
+        <attribute name="isEquipped" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isPlayground" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isPurchased" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="price" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+    </entity>
     <entity name="UserEntity" representedClassName="UserEntity" syncable="YES" codeGenerationType="class">
         <attribute name="money" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
     </entity>
     <elements>
         <element name="UserEntity" positionX="-63" positionY="-18" width="128" height="44"/>
+        <element name="ItemEntity" positionX="-63" positionY="-9" width="128" height="134"/>
     </elements>
 </model>

--- a/StudyBuddyApp/StudyBuddyApp/ViewModel.swift
+++ b/StudyBuddyApp/StudyBuddyApp/ViewModel.swift
@@ -21,6 +21,10 @@ class ViewModel: ObservableObject {
   @Published var user: User = User()
   @Published var showTaskErrorMessage: Bool = false
   
+  private var storeNeedUpdate: Bool = true
+  private var playgroundNeedUpdate: Bool = true
+  private var characterNeedUpdate: Bool = true
+  
   func createTask(name: String, duration: TimeInterval, category: TaskCategory, isStarted: Bool, completion: @escaping () -> Void) {
     if (name == "") {
       showTaskErrorMessage = true
@@ -99,6 +103,9 @@ class ViewModel: ObservableObject {
           break;
         }
       }
+      storeNeedUpdate = true
+      playgroundNeedUpdate = true
+      characterNeedUpdate = true
       do {
         try context.save()
       } catch {
@@ -107,73 +114,98 @@ class ViewModel: ObservableObject {
     }
   }
   
-  func fetchItemData(){
+  func fetchItemData(modelName: String){
     let context = appDelegate.persistentContainer.viewContext
     if let entity = NSEntityDescription.entity(forEntityName: "ItemEntity", in: context){
       let result = fetchRecordsForEntity("UserEntity", inManagedObjectContext: context)
-      if result.count == 0{
-        // init for first time only
-        var initialItems : [PlaygroundItem] = []
-        for index in 1...5 {
-          let painting = PlaygroundItem(name: "Painting \(index)", price: 400, image: "hill_painting", category: PlaygroundItemCategory.Wall)
-          let carpet = PlaygroundItem(name: "Lamp \(index)", price: 500, image: "yellow_lamp", category: PlaygroundItemCategory.Floor)
-          store.addPlaygroundItem(item: painting)
-          store.addPlaygroundItem(item: carpet)
-          initialItems.append(painting)
-          initialItems.append(carpet)
-        }
-        for item in initialItems{
-          let newItem = NSManagedObject(entity: entity, insertInto: context)
-          newItem.setValue(item.name, forKey: "name")
-          newItem.setValue(item.price, forKey: "price")
-          newItem.setValue(item.category.rawValue, forKey: "category")
-          newItem.setValue(item.image, forKey: "image")
-          newItem.setValue(false, forKey: "isEquipped")
-          newItem.setValue(false, forKey: "isPurchased")
-          newItem.setValue(true, forKey: "isPlayground") // UPDATE THIS LOGIC IF WE HAVE ACCESSORY ITEM
-        }
-        do {
-          try context.save()
-        } catch {
-          NSLog("[Contacts] ERROR: Failed to save Item data")
-        }
-      }
-      else{
-        for data in result{
-          let name = data.value(forKey: "name") as? String ?? ""
-          let price = data.value(forKey: "price") as? Int ?? 0
-          let image = data.value(forKey: "image") as? String ?? ""
-          let category = data.value(forKey: "category") as? String ?? ""
-          let isPlayground = data.value(forKey: "isPlayground") as? Bool ?? false
-          let isPurchased = data.value(forKey: "isPurchased") as? Bool ?? false
-          let isEquipped = data.value(forKey: "isEquipped") as? Bool ?? false
-          if (isPlayground){
-            let item = PlaygroundItem(name:name, price: price, image: image, category: PlaygroundItemCategory(rawValue: category)!)
-            if (isPurchased){
+      switch (modelName){
+        case "store":
+          if result.count == 0{
+            // init for first time only
+            var initialItems : [PlaygroundItem] = []
+            for index in 1...5 {
+              let painting = PlaygroundItem(name: "Painting \(index)", price: 400, image: "hill_painting", category: PlaygroundItemCategory.Wall)
+              let carpet = PlaygroundItem(name: "Lamp \(index)", price: 500, image: "yellow_lamp", category: PlaygroundItemCategory.Floor)
+              store.addPlaygroundItem(item: painting)
+              store.addPlaygroundItem(item: carpet)
+              initialItems.append(painting)
+              initialItems.append(carpet)
+            }
+            for item in initialItems{
+              let newItem = NSManagedObject(entity: entity, insertInto: context)
+              newItem.setValue(item.name, forKey: "name")
+              newItem.setValue(item.price, forKey: "price")
+              newItem.setValue(item.category.rawValue, forKey: "category")
+              newItem.setValue(item.image, forKey: "image")
+              newItem.setValue(false, forKey: "isEquipped")
+              newItem.setValue(false, forKey: "isPurchased")
+              newItem.setValue(true, forKey: "isPlayground") // UPDATE THIS LOGIC IF WE HAVE ACCESSORY ITEM
+            }
+            do {
+              try context.save()
+            } catch {
+              NSLog("[Contacts] ERROR: Failed to save Item data")
+            }
+          }
+          else{
+            for data in result{
+              let name = data.value(forKey: "name") as? String ?? ""
+              let price = data.value(forKey: "price") as? Int ?? 0
+              let image = data.value(forKey: "image") as? String ?? ""
+              let category = data.value(forKey: "category") as? String ?? ""
+              let isPlayground = data.value(forKey: "isPlayground") as? Bool ?? false
+              let isPurchased = data.value(forKey: "isPurchased") as? Bool ?? false
+              if (!isPurchased){
+                if (isPlayground){
+                  let item = PlaygroundItem(name:name, price: price, image: image, category: PlaygroundItemCategory(rawValue: category)!)
+                  store.addPlaygroundItem(item: item)
+                }
+                else{
+                  let item = AccessoryItem(name:name, price: price, image: image, category: AccessoryItemCategory(rawValue: category)!)
+                  store.addAccessoryItem(item: item)
+                }
+              }
+            }
+          }
+          break
+        case "playground":
+          for data in result{
+            let name = data.value(forKey: "name") as? String ?? ""
+            let price = data.value(forKey: "price") as? Int ?? 0
+            let image = data.value(forKey: "image") as? String ?? ""
+            let category = data.value(forKey: "category") as? String ?? ""
+            let isPlayground = data.value(forKey: "isPlayground") as? Bool ?? false
+            let isPurchased = data.value(forKey: "isPurchased") as? Bool ?? false
+            let isEquipped = data.value(forKey: "isEquipped") as? Bool ?? false
+            if (isPlayground && isPurchased){
+              let item = PlaygroundItem(name:name, price: price, image: image, category: PlaygroundItemCategory(rawValue: category)!)
               playground.onNewItemPurchased(item: item)
-              playground.resetNumNewItem()
               if (isEquipped){
                 playground.moveIntoPlayground(item: item)
               }
             }
-            else{
-              store.addPlaygroundItem(item: item)
-            }
           }
-          else{
-            let item = AccessoryItem(name:name, price: price, image: image, category: AccessoryItemCategory(rawValue: category)!)
-            if (isPurchased){
+          break
+        case "character":
+          for data in result{
+            let name = data.value(forKey: "name") as? String ?? ""
+            let price = data.value(forKey: "price") as? Int ?? 0
+            let image = data.value(forKey: "image") as? String ?? ""
+            let category = data.value(forKey: "category") as? String ?? ""
+            let isPlayground = data.value(forKey: "isPlayground") as? Bool ?? false
+            let isPurchased = data.value(forKey: "isPurchased") as? Bool ?? false
+            let isEquipped = data.value(forKey: "isEquipped") as? Bool ?? false
+            if (!isPlayground && isPurchased){
+              let item = AccessoryItem(name:name, price: price, image: image, category: AccessoryItemCategory(rawValue: category)!)
               character.onNewItemPurchased(item: item)
-              character.resetNumNewItem()
               if (isEquipped){
                 character.wearItem(item: item)
               }
             }
-            else{
-              store.addAccessoryItem(item: item)
-            }
           }
-        }
+          break
+        default:
+          break
       }
     }
   }
@@ -181,19 +213,28 @@ class ViewModel: ObservableObject {
   func updateItemData(viewToUpdate: String){
     switch (viewToUpdate.lowercased()){
       case "store":
-        store = Store()
+        if (storeNeedUpdate){
+          store = Store()
+          storeNeedUpdate = false
+        }
         break
       case "character":
-        let name = character.getName()
-        character = Character(name: name)
-        break;
+        if (characterNeedUpdate){
+          let name = character.getName()
+          character = Character(name: name)
+          characterNeedUpdate = false
+        }
+        break
       case "playground":
-        playground = Playground()
-        break;
+        if (playgroundNeedUpdate){
+          playground = Playground()
+          playgroundNeedUpdate = false
+        }
+        break
       default:
-        break;
+        break
     }
-    fetchItemData()
+    fetchItemData(modelName: viewToUpdate)
   }
   
   func saveUserData(){


### PR DESCRIPTION
To use item coredata mechanism:
1. Update item. When calling updateItemData in viewmodel from views, need to include the name of the view ("store", "playground", "character" ) this helps as we just need run update speicific to whatever view player is looking at right now and not other ones
2. Save item. Calling saveItemData requires three parameter: 1. the item's name, 2. whether the item is newly purchased or not (should be true in most if not all cases) and 3. whether the item is equipped (equipped meaning "worn" for accessories, and "decorated" for playground items).


Down the road we are going to need a mechanism for adding new available items to the store. Don't need it for now